### PR TITLE
added Serialize instance for EndPointAddress

### DIFF
--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -65,6 +65,7 @@ Source-Repository head
 Library
   Build-Depends:   base >= 4.3 && < 5,
                    binary >= 0.5 && < 0.7,
+                   cereal >= 0.3.5.0 && < 0.5,
                    bytestring >= 0.9 && < 0.11,
                    transformers >= 0.2 && < 0.4
   Exposed-Modules: Network.Transport,

--- a/src/Network/Transport.hs
+++ b/src/Network/Transport.hs
@@ -30,6 +30,7 @@ import Control.Exception (Exception)
 import Control.Applicative ((<$>))
 import Data.Typeable (Typeable)
 import Data.Binary (Binary(get, put))
+import qualified Data.Serialize as S (Serialize,put,get)
 import Data.Word (Word64)
 
 --------------------------------------------------------------------------------
@@ -132,6 +133,10 @@ newtype EndPointAddress = EndPointAddress { endPointAddressToByteString :: ByteS
 instance Binary EndPointAddress where
   put = put . endPointAddressToByteString
   get = EndPointAddress . BS.copy <$> get
+
+instance S.Serialize EndPointAddress where
+  put = S.put . endPointAddressToByteString
+  get = EndPointAddress . BS.copy <$> S.get
 
 instance Show EndPointAddress where
   show = BSC.unpack . endPointAddressToByteString


### PR DESCRIPTION
Adds a `Serialize` instance for `EndPointAddress`. This adds binary serialization support using the `cereal` package, on top of the existing support for the `binary` package with the `Binary` instance.

@edsko , could you take a look at this when you get a chance? There might be a good reason that this is not currently in `Network.Transport` that I am not aware of?
