### PR TITLE
Fix build under GHC 7.4.

### DIFF
--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -68,6 +68,8 @@ Library
                    bytestring >= 0.9 && < 0.11,
                    hashable >= 1.2.0.5 && < 1.3,
                    transformers >= 0.2 && < 0.4
+  if impl(ghc < 7.6)
+    Build-Depends: ghc-prim >= 0.2 && < 0.4
   Exposed-Modules: Network.Transport,
                    Network.Transport.Util
                    Network.Transport.Internal


### PR DESCRIPTION
I don't have and don't use GHC 7.4, but travis CI still uses this version. I believe this patch should fix CI.
