### PR TITLE
Binary instance for 'Reliability' type.

### DIFF
--- a/src/Network/Transport.hs
+++ b/src/Network/Transport.hs
@@ -110,7 +110,9 @@ data Reliability =
     ReliableOrdered
   | ReliableUnordered
   | Unreliable
-  deriving (Show, Eq)
+  deriving (Show, Eq, Typeable, Generic)
+
+instance Binary Reliability
 
 -- | Multicast group.
 data MulticastGroup = MulticastGroup {


### PR DESCRIPTION
Reliability is a basic enumeration whose values it is sometimes useful to communicate over the network, e.g. to tell a remote node to create a connection of the given reliability type.
