### PR TITLE
Created Data instance for EndPointAddress.

### DIFF
--- a/src/Network/Transport.hs
+++ b/src/Network/Transport.hs
@@ -32,6 +32,7 @@ import Data.Typeable (Typeable)
 import Data.Binary (Binary(put, get), putWord8, getWord8)
 import Data.Hashable
 import Data.Word (Word64)
+import Data.Data (Data)
 
 --------------------------------------------------------------------------------
 -- Main API                                                                   --
@@ -140,7 +141,7 @@ data MulticastGroup = MulticastGroup {
 
 -- | EndPointAddress of an endpoint.
 newtype EndPointAddress = EndPointAddress { endPointAddressToByteString :: ByteString }
-  deriving (Eq, Ord, Typeable, Hashable)
+  deriving (Eq, Ord, Typeable, Data, Hashable)
 
 instance Binary EndPointAddress where
   put = put . endPointAddressToByteString


### PR DESCRIPTION
Adding an instance of Data for EndPointAddress allows the address as well as dependent types like ProcessId to be stored in data-structures that require their elements to have an instance of Data.  For example, the IxSet.
