### PR TITLE
foreigns htonl, ntohl, htons, ntohs are imported from ws2_32 on windows

### DIFF
--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -82,3 +82,5 @@ Library
                    CPP
   GHC-Options:     -Wall -fno-warn-unused-do-bind
   HS-Source-Dirs:  src
+  if os(win32)
+      extra-libraries: ws2_32

--- a/src/Network/Transport/Internal.hs
+++ b/src/Network/Transport/Internal.hs
@@ -51,10 +51,21 @@ import GHC.IO (unsafeUnmask)
 import System.Timeout (timeout)
 --import Control.Concurrent (myThreadId)
 
+#ifdef mingw32_HOST_OS
+
+foreign import stdcall unsafe "htonl" htonl :: CInt -> CInt
+foreign import stdcall unsafe "ntohl" ntohl :: CInt -> CInt
+foreign import stdcall unsafe "htons" htons :: CShort -> CShort
+foreign import stdcall unsafe "ntohs" ntohs :: CShort -> CShort
+
+#else
+
 foreign import ccall unsafe "htonl" htonl :: CInt -> CInt
 foreign import ccall unsafe "ntohl" ntohl :: CInt -> CInt
 foreign import ccall unsafe "htons" htons :: CShort -> CShort
 foreign import ccall unsafe "ntohs" ntohs :: CShort -> CShort
+
+#endif
 
 -- | Serialize 32-bit to network byte order
 encodeInt32 :: Enum a => a -> ByteString


### PR DESCRIPTION
This solves the linking issue on Windows

> undefined reference to `ntohl'
