### PR TITLE
Add NFData instance to EndPointAddress

### DIFF
--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -68,7 +68,8 @@ Library
                    binary >= 0.5 && < 0.8,
                    bytestring >= 0.9 && < 0.11,
                    hashable >= 1.2.0.5 && < 1.3,
-                   transformers >= 0.2 && < 0.5
+                   transformers >= 0.2 && < 0.5,
+                   deepseq >= 1.0 && < 1.5
   if impl(ghc < 7.6)
     Build-Depends: ghc-prim >= 0.2 && < 0.4
   Exposed-Modules: Network.Transport,

--- a/src/Network/Transport.hs
+++ b/src/Network/Transport.hs
@@ -26,6 +26,7 @@ module Network.Transport
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS (copy)
 import qualified Data.ByteString.Char8 as BSC (unpack)
+import Control.DeepSeq (NFData(rnf))
 import Control.Exception (Exception)
 import Control.Applicative ((<$>))
 import Data.Typeable (Typeable)
@@ -149,6 +150,8 @@ instance Binary EndPointAddress where
 
 instance Show EndPointAddress where
   show = BSC.unpack . endPointAddressToByteString
+
+instance NFData EndPointAddress where rnf x = x `seq` ()
 
 -- | EndPointAddress of a multicast group.
 newtype MulticastAddress = MulticastAddress { multicastAddressToByteString :: ByteString }


### PR DESCRIPTION
This change is required in order to make network-transport compatible with ghc-7.10. As a side effect this change fixes `NFData` instance