### PR TITLE
Increase upper bound of transformers

### DIFF
--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -68,7 +68,7 @@ Library
                    binary >= 0.5 && < 0.9,
                    bytestring >= 0.9 && < 0.11,
                    hashable >= 1.2.0.5 && < 1.3,
-                   transformers >= 0.2 && < 0.5,
+                   transformers >= 0.2 && < 0.6,
                    deepseq >= 1.0 && < 1.5
   if impl(ghc < 7.6)
     Build-Depends: ghc-prim >= 0.2 && < 0.4


### PR DESCRIPTION
Since GHC8 comes with transformers-0.5.2.0

This compiles with GHC 8.0.1-rc4.