### PR TITLE
Define decodeWord32, encodeWord32

### DIFF
--- a/src/Network/Transport/Internal.hs
+++ b/src/Network/Transport/Internal.hs
@@ -84,10 +84,7 @@ decodeWord32 bs
   | BS.length bs /= 4 = throw $ userError "decodeWord32: not 4 bytes"
   | otherwise         = BSI.inlinePerformIO $ do
       let (fp, offset, _) = BSI.toForeignPtr bs
-      withForeignPtr fp $ \p -> do
-        w32 <- peekByteOff p offset
-        -- fromIntegral :: CInt -> Word32
-        return (fromIntegral . ntohl $ w32)
+      withForeignPtr fp $ \p -> ntohl <$> peekByteOff p offset
 
 -- | Serialize 16-bit to network byte order
 encodeWord16 :: Word16 -> ByteString
@@ -102,10 +99,7 @@ decodeWord16 bs
   | BS.length bs /= 2 = throw $ userError "decodeWord16: not 2 bytes"
   | otherwise         = BSI.inlinePerformIO $ do
       let (fp, offset, _) = BSI.toForeignPtr bs
-      withForeignPtr fp $ \p -> do
-        w16 <- peekByteOff p offset
-        -- fromIntegral :: CInt -> Word16
-        return (fromIntegral . ntohs $ w16)
+      withForeignPtr fp $ \p -> ntohs <$> peekByteOff p offset
 
 -- | Encode an Enum in 32 bits by encoding its signed Int equivalent (beware
 -- of truncation, an Enum may contain more than 2^32 points).

--- a/src/Network/Transport/Internal.hs
+++ b/src/Network/Transport/Internal.hs
@@ -73,9 +73,9 @@ foreign import ccall unsafe "ntohs" ntohs :: Word16 -> Word16
 
 -- | Serialize 32-bit to network byte order
 encodeWord32 :: Word32 -> ByteString
-encodeWord32 i32 =
+encodeWord32 w32 =
   BSI.unsafeCreate 4 $ \p ->
-    pokeByteOff p 0 (htonl i32)
+    pokeByteOff p 0 (htonl w32)
 
 -- | Deserialize 32-bit from network byte order
 -- Throws an IO exception if this is not exactly 32 bits.

--- a/src/Network/Transport/Internal.hs
+++ b/src/Network/Transport/Internal.hs
@@ -28,7 +28,6 @@ import Prelude hiding (catch)
 #endif
 
 import Foreign.Storable (pokeByteOff, peekByteOff)
-import Foreign.C (CInt(..), CShort(..))
 import Foreign.ForeignPtr (withForeignPtr)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS (length)
@@ -58,17 +57,17 @@ import System.Timeout (timeout)
 
 #ifdef mingw32_HOST_OS
 
-foreign import stdcall unsafe "htonl" htonl :: CInt -> CInt
-foreign import stdcall unsafe "ntohl" ntohl :: CInt -> CInt
-foreign import stdcall unsafe "htons" htons :: CShort -> CShort
-foreign import stdcall unsafe "ntohs" ntohs :: CShort -> CShort
+foreign import stdcall unsafe "htonl" htonl :: Word32 -> Word32
+foreign import stdcall unsafe "ntohl" ntohl :: Word32 -> Word32
+foreign import stdcall unsafe "htons" htons :: Word16 -> Word16
+foreign import stdcall unsafe "ntohs" ntohs :: Word16 -> Word16
 
 #else
 
-foreign import ccall unsafe "htonl" htonl :: CInt -> CInt
-foreign import ccall unsafe "ntohl" ntohl :: CInt -> CInt
-foreign import ccall unsafe "htons" htons :: CShort -> CShort
-foreign import ccall unsafe "ntohs" ntohs :: CShort -> CShort
+foreign import ccall unsafe "htonl" htonl :: Word32 -> Word32
+foreign import ccall unsafe "ntohl" ntohl :: Word32 -> Word32
+foreign import ccall unsafe "htons" htons :: Word16 -> Word16
+foreign import ccall unsafe "ntohs" ntohs :: Word16 -> Word16
 
 #endif
 
@@ -76,8 +75,7 @@ foreign import ccall unsafe "ntohs" ntohs :: CShort -> CShort
 encodeWord32 :: Word32 -> ByteString
 encodeWord32 i32 =
   BSI.unsafeCreate 4 $ \p ->
-    -- fromIntegral :: Word32 -> CInt
-    pokeByteOff p 0 (htonl . fromIntegral $ i32)
+    pokeByteOff p 0 (htonl i32)
 
 -- | Deserialize 32-bit from network byte order
 -- Throws an IO exception if this is not exactly 32 bits.
@@ -93,10 +91,9 @@ decodeWord32 bs
 
 -- | Serialize 16-bit to network byte order
 encodeWord16 :: Word16 -> ByteString
-encodeWord16 i16 =
+encodeWord16 w16 =
   BSI.unsafeCreate 2 $ \p ->
-    -- fromIntegral :: Word16 -> CInt
-    pokeByteOff p 0 (htons . fromIntegral $ i16)
+    pokeByteOff p 0 (htons w16)
 
 -- | Deserialize 16-bit from network byte order
 -- Throws an IO exception if this is not exactly 16 bits.


### PR DESCRIPTION
From these monomorphic functions, the general `Enum` and `Num` varieties are
derived.