### PR TITLE
update transformers version to 0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .cabal-sandbox
 cabal.sandbox.config
 .stack*
+dist-newstyle/

--- a/network-transport.cabal
+++ b/network-transport.cabal
@@ -68,7 +68,7 @@ Library
                    binary >= 0.5 && < 0.9,
                    bytestring >= 0.9 && < 0.12,
                    hashable >= 1.2.0.5 && < 1.5,
-                   transformers >= 0.2 && < 0.6,
+                   transformers >= 0.6 && < 0.7,
                    deepseq >= 1.0 && < 1.5
   if impl(ghc < 7.6)
     Build-Depends: ghc-prim >= 0.2 && < 0.4


### PR DESCRIPTION
Can we do something like this?

Or even just adding 0.6 in the range would be helpful, as otherwise it doesn't compile with GHC 9.6.2

Switched to fork for now.

Thank you!